### PR TITLE
Revert "chore(deps): update registry-1.docker.io/bitnamicharts/redis docker tag to v20.10.0"

### DIFF
--- a/apps/database/redis.yaml
+++ b/apps/database/redis.yaml
@@ -13,7 +13,7 @@ spec:
   sources:
     - repoURL: registry-1.docker.io/bitnamicharts
       chart: redis
-      targetRevision: 20.10.0
+      targetRevision: 20.8.0
       helm:
         valuesObject:
           auth:


### PR DESCRIPTION
Reverts carterjgreen/home-server#782

https://github.com/bitnami/charts/pull/32117#issuecomment-2688110555